### PR TITLE
install LEDA-free and RS from AUR

### DIFF
--- a/ArchLinux/Dockerfile
+++ b/ArchLinux/Dockerfile
@@ -48,9 +48,15 @@ RUN curl -s -SL https://aur.archlinux.org/cgit/aur.git/snapshot/ipe.tar.gz | tar
 RUN curl -s -SL https://aur.archlinux.org/cgit/aur.git/snapshot/esbtl.tar.gz | tar xzv && \
     cd esbtl && makepkg --noconfirm
 
+RUN curl -s -SL https://aur.archlinux.org/cgit/aur.git/snapshot/leda-free.tar.gz | tar xzv && \
+    cd leda-free && makepkg --noconfirm
+
+RUN curl -s -SL https://aur.archlinux.org/cgit/aur.git/snapshot/librs.tar.gz | tar xzv && \
+    cd librs && makepkg --noconfirm
+
 USER root
-RUN pacman -U --noconfirm ipe/*.pkg.tar.xz esbtl/*.pkg.tar.xz && \
-    rm -rf ipe esbtl
+RUN pacman -U --noconfirm ipe/*.pkg.tar.xz esbtl/*.pkg.tar.xz leda-free/*.pkg.tar.xz librs/*.pkg.tar.xz && \
+    rm -rf ipe esbtl leda-free librs
 
 ENV CGAL_TEST_PLATFORM="ArchLinux"
 ENV CGAL_CMAKE_FLAGS="(\"-DWITH_CGAL_Qt3:BOOL=OFF\")"

--- a/ArchLinux/Dockerfile
+++ b/ArchLinux/Dockerfile
@@ -22,6 +22,7 @@ RUN pacman -S --noconfirm \
               mesa \
               mpfi \
               mpfr \
+              ntl \
               poppler \
               python2 \
               libqglviewer \


### PR DESCRIPTION
Only for the Arch Linux testsuite; I don't think that those packages are (semi-)officially available in any other distribution's repositories.