### PR TITLE
Arch Linux: add NTL, LEDA-free and RS

### DIFF
--- a/ArchLinux-CXX14/Dockerfile
+++ b/ArchLinux-CXX14/Dockerfile
@@ -2,4 +2,4 @@ FROM cgal/testsuite-docker:archlinux
 MAINTAINER Philipp Moeller <bootsarehax@gmail.com>
 
 ENV CGAL_TEST_PLATFORM="ArchLinux-CXX14"
-ENV CGAL_CMAKE_FLAGS="(\"-DWITH_CGAL_Qt3:BOOL=OFF\" \"-DCGAL_CXX_FLAGS=-Wall -std=c++14\")"
+ENV CGAL_CMAKE_FLAGS="(\"-DWITH_CGAL_Qt3:BOOL=OFF\" \"-DLEDA_INCLUDE_DIR=/usr/include/LEDA\" \"-DCGAL_CXX_FLAGS=-Wall -std=c++14\")"

--- a/ArchLinux-clang-CXX14/Dockerfile
+++ b/ArchLinux-clang-CXX14/Dockerfile
@@ -2,4 +2,4 @@ FROM cgal/testsuite-docker:archlinux-clang
 MAINTAINER Philipp Moeller <bootsarehax@gmail.com>
 
 ENV CGAL_TEST_PLATFORM="ArchLinux-clang-CXX14"
-ENV CGAL_CMAKE_FLAGS="(\"-DWITH_CGAL_Qt3:BOOL=OFF\" \"-DCMAKE_C_COMPILER:FILEPATH=/bin/clang\" \"-DCMAKE_CXX_COMPILER:FILEPATH=/bin/clang++\" \"-DCGAL_CXX_FLAGS=-Wall -std=c++14\")" CXX=/bin/clang++ CC=/bin/clang
+ENV CGAL_CMAKE_FLAGS="(\"-DWITH_CGAL_Qt3:BOOL=OFF\" \"-DLEDA_INCLUDE_DIR=/usr/include/LEDA\" \"-DCMAKE_C_COMPILER:FILEPATH=/bin/clang\" \"-DCMAKE_CXX_COMPILER:FILEPATH=/bin/clang++\" \"-DCGAL_CXX_FLAGS=-Wall -std=c++14\")" CXX=/bin/clang++ CC=/bin/clang

--- a/ArchLinux-clang-CXX1z/Dockerfile
+++ b/ArchLinux-clang-CXX1z/Dockerfile
@@ -2,4 +2,4 @@ FROM cgal/testsuite-docker:archlinux-clang
 MAINTAINER Philipp Moeller <bootsarehax@gmail.com>
 
 ENV CGAL_TEST_PLATFORM="ArchLinux-clang-CXX1z"
-ENV CGAL_CMAKE_FLAGS="(\"-DWITH_CGAL_Qt3:BOOL=OFF\" \"-DCMAKE_C_COMPILER:FILEPATH=/bin/clang\" \"-DCMAKE_CXX_COMPILER:FILEPATH=/bin/clang++\" \"-DCGAL_CXX_FLAGS=-Wall -std=c++1z\")" CXX=/bin/clang++ CC=/bin/clang
+ENV CGAL_CMAKE_FLAGS="(\"-DWITH_CGAL_Qt3:BOOL=OFF\" \"-DLEDA_INCLUDE_DIR=/usr/include/LEDA\" \"-DCMAKE_C_COMPILER:FILEPATH=/bin/clang\" \"-DCMAKE_CXX_COMPILER:FILEPATH=/bin/clang++\" \"-DCGAL_CXX_FLAGS=-Wall -std=c++1z\")" CXX=/bin/clang++ CC=/bin/clang

--- a/ArchLinux-clang-Release/Dockerfile
+++ b/ArchLinux-clang-Release/Dockerfile
@@ -2,4 +2,4 @@ FROM cgal/testsuite-docker:archlinux-clang
 MAINTAINER Philipp Moeller <bootsarehax@gmail.com>
 
 ENV CGAL_TEST_PLATFORM="ArchLinux-clang-Release"
-ENV CGAL_CMAKE_FLAGS="(\"-DCMAKE_BUILD_TYPE=Release\" \"-DCMAKE_CXX_FLAGS_RELEASE=-O3 -DCGAL_NDEBUG\" \"-DWITH_CGAL_Qt3:BOOL=OFF\" \"-DCMAKE_C_COMPILER:FILEPATH=/bin/clang\" \"-DCMAKE_CXX_COMPILER:FILEPATH=/bin/clang++\" \"-DCGAL_CXX_FLAGS=-Wall\")" CXX=/bin/clang++ CC=/bin/clang
+ENV CGAL_CMAKE_FLAGS="(\"-DCMAKE_BUILD_TYPE=Release\" \"-DCMAKE_CXX_FLAGS_RELEASE=-O3 -DCGAL_NDEBUG\" \"-DWITH_CGAL_Qt3:BOOL=OFF\" \"-DLEDA_INCLUDE_DIR=/usr/include/LEDA\" \"-DCMAKE_C_COMPILER:FILEPATH=/bin/clang\" \"-DCMAKE_CXX_COMPILER:FILEPATH=/bin/clang++\" \"-DCGAL_CXX_FLAGS=-Wall\")" CXX=/bin/clang++ CC=/bin/clang

--- a/ArchLinux-clang-svn/Dockerfile
+++ b/ArchLinux-clang-svn/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Philipp Moeller <bootsarehax@gmail.com>
 
 # Tools needed to build llvm
 RUN pacman -Syyu --noconfirm
-RUN pacman -S --noconfirm --asdeps \
+RUN pacman -S --noconfirm --needed --asdeps \
               chrpath \
               ocaml-ctypes \
               ocaml-findlib \

--- a/ArchLinux-clang-svn/Dockerfile
+++ b/ArchLinux-clang-svn/Dockerfile
@@ -4,13 +4,16 @@ MAINTAINER Philipp Moeller <bootsarehax@gmail.com>
 
 # Tools needed to build llvm
 RUN pacman -Syyu --noconfirm
-RUN pacman -S --noconfirm \
+RUN pacman -S --noconfirm --asdeps \
               chrpath \
               ocaml-ctypes \
               ocaml-findlib \
-              python-sphinx \
+              python2-sphinx \
               python2 \
               subversion
+
+# clean up the package cache
+RUN yes | pacman -Scc
 
 USER makepkg
 WORKDIR /tmp/makepkg

--- a/ArchLinux-clang-svn/Dockerfile
+++ b/ArchLinux-clang-svn/Dockerfile
@@ -21,12 +21,21 @@ WORKDIR /tmp/makepkg
 RUN curl -s -SL https://aur.archlinux.org/cgit/aur.git/snapshot/llvm-svn.tar.gz | tar xzv && \
     cd llvm-svn && makepkg --noconfirm
 
-# The libc++-svn package has not been ported to AUR4.
+# Outdated: The libc++-svn package has not been ported to AUR4;
+# the llvm-libs are now provided as a sub-package of llvm-svn
 # RUN curl -s -SL https://aur.archlinux.org/packages/li/libc++-svn/libc++-svn.tar.gz | tar xzv && \
 #     cd libc++-svn && makepkg --noconfirm
 
 USER root
-RUN pacman --noconfirm -U llvm-svn/*.pkg.tar.xz libc++-svn/*.pkg.tar.xz && rm -rf llvm-svn libc++-svn
+
+# remove llvm-libs without dependency checks to prepare replacement
+# (pulled in as dependency of libqglviewer -> mesa)...
+RUN pacman --noconfirm -Rdd llvm-libs
+# ... and install the llvm-svn packages
+RUN pacman --noconfirm -U llvm-svn/*.pkg.tar.xz && rm -rf llvm-svn
+
+# see above: not necessary anymore
+# RUN pacman --noconfirm -U libc++-svn/*.pkg.tar.xz && rm -rf libc++-svn
 
 ENV CC=clang
 ENV CXX=clang++

--- a/ArchLinux-clang-svn/Dockerfile
+++ b/ArchLinux-clang-svn/Dockerfile
@@ -28,4 +28,4 @@ RUN pacman --noconfirm -U llvm-svn/*.pkg.tar.xz libc++-svn/*.pkg.tar.xz && rm -r
 ENV CC=clang
 ENV CXX=clang++
 ENV CGAL_TEST_PLATFORM="ArchLinux-clang-svn"
-ENV CGAL_CMAKE_FLAGS="(\"-DCGAL_CXX_FLAGS=-Wall -Wextra -std=c++14 -stdlib=libc++\" \"-DWITH_CGAL_Qt3:BOOL=OFF\")"
+ENV CGAL_CMAKE_FLAGS="(\"-DCGAL_CXX_FLAGS=-Wall -Wextra -std=c++14 -stdlib=libc++\" \"-DWITH_CGAL_Qt3:BOOL=OFF\" \"-DLEDA_INCLUDE_DIR=/usr/include/LEDA\")"

--- a/ArchLinux-clang/Dockerfile
+++ b/ArchLinux-clang/Dockerfile
@@ -4,4 +4,4 @@ MAINTAINER Philipp Moeller <bootsarehax@gmail.com>
 RUN pacman -Syyu --noconfirm && pacman -S --noconfirm clang && pacman -Scc --noconfirm
 
 ENV CGAL_TEST_PLATFORM="ArchLinux-clang"
-ENV CGAL_CMAKE_FLAGS="(\"-DWITH_CGAL_Qt3:BOOL=OFF\" \"-DCMAKE_C_COMPILER:FILEPATH=/bin/clang\" \"-DCMAKE_CXX_COMPILER:FILEPATH=/bin/clang++\" \"-DCGAL_CXX_FLAGS=-Wall\")" CXX=/bin/clang++ CC=/bin/clang
+ENV CGAL_CMAKE_FLAGS="(\"-DWITH_CGAL_Qt3:BOOL=OFF\" \"-DLEDA_INCLUDE_DIR=/usr/include/LEDA\" \"-DCMAKE_C_COMPILER:FILEPATH=/bin/clang\" \"-DCMAKE_CXX_COMPILER:FILEPATH=/bin/clang++\" \"-DCGAL_CXX_FLAGS=-Wall\")" CXX=/bin/clang++ CC=/bin/clang

--- a/ArchLinux/Dockerfile
+++ b/ArchLinux/Dockerfile
@@ -48,9 +48,15 @@ RUN curl -s -SL https://aur.archlinux.org/cgit/aur.git/snapshot/ipe.tar.gz | tar
 RUN curl -s -SL https://aur.archlinux.org/cgit/aur.git/snapshot/esbtl.tar.gz | tar xzv && \
     cd esbtl && makepkg --noconfirm
 
+RUN curl -s -SL https://aur.archlinux.org/cgit/aur.git/snapshot/leda-free.tar.gz | tar xzv && \
+    cd leda-free && makepkg --noconfirm
+
+RUN curl -s -SL https://aur.archlinux.org/cgit/aur.git/snapshot/librs.tar.gz | tar xzv && \
+    cd librs && makepkg --noconfirm
+
 USER root
-RUN pacman -U --noconfirm ipe/*.pkg.tar.xz esbtl/*.pkg.tar.xz && \
-    rm -rf ipe esbtl
+RUN pacman -U --noconfirm ipe/*.pkg.tar.xz esbtl/*.pkg.tar.xz leda-free/*.pkg.tar.xz librs/*.pkg.tar.xz && \
+    rm -rf ipe esbtl leda-free librs
 
 ENV CGAL_TEST_PLATFORM="ArchLinux"
 ENV CGAL_CMAKE_FLAGS="(\"-DWITH_CGAL_Qt3:BOOL=OFF\")"

--- a/ArchLinux/Dockerfile
+++ b/ArchLinux/Dockerfile
@@ -1,17 +1,36 @@
 FROM base/archlinux:latest
 MAINTAINER Philipp Moeller <bootsarehax@gmail.com>, Alexander Kobel <alexander.kobel@mpi-inf.mpg.de>
 
-# base/archlinux is really old; in particular, the packager keys are horribly outdated.
-# We delete the original keyring and refresh it from scratch before the real setup:
+# base/archlinux is /ancient/; in particular, the packager keys are horribly outdated.
+# We need to repopulate the keyring from scratch before the real setup:
 
 # install the official Arch Linux keyring package
 RUN pacman -Sy --noconfirm archlinux-keyring
 
-# remove the old database of trusted keys the hard way and initialize a new database
-# This Should hopefully become unnecessary at some point, and should be commented because it takes a while;
-# but right now it's required as a last resort bacause the base image is really, /really/ ancient.)
-RUN rm -rf /etc/pacman.d/gnupg && \
-    pacman-key --init
+# This is a "soft" version that deletes all packager keys, but preserves the local master key.
+#   pacman-key --list-keys | grep -B1 '\[ultimate\]' | head -n1 | cut -d/ -f2 | cut -d' ' -f1
+# determines the fingerprint of the local "Pacman Keyring Master Key" (unique one with ultimate trust);
+# we delete every key except this one.
+RUN pacman-key --delete \
+    $(pacman-key --list-keys \
+      | grep '^pub' | cut -d/ -f2 | cut -d' ' -f1 \
+      | grep -v $(pacman-key --list-keys | grep -B1 '\[ultimate\]' | head -n1 | cut -d/ -f2 | cut -d' ' -f1))
+
+# # Here is the equivalent call for more recent pacman-key syntax (once the base image gets updated):
+# #   pacman-key --list-keys | grep -B1 '\[ultimate\]' | head -n1
+# # determines the fingerprint of the local "Pacman Keyring Master Key" (unique one with ultimate trust);
+# # we delete every key except this one.
+# RUN pacman-key --delete \
+#     $(pacman-key --list-keys \
+#       | grep '^  ' \
+#       | grep -v $(pacman-key --list-keys | grep -B1 '\[ultimate\]' | head -n1))
+
+# # Finally, here is a way to clear the old database of trusted keys the HARD way and initialize a new database.
+# # This should hopefully be unnecessary except in the darkest hours; but nobody knows the trouble I've seen...
+# # Regenerating a new private key requires a lot of randomness and is not suited for a virtual machine where randomness is scarce.
+# # Only use it as a last resort if nothing else works.
+# RUN rm -rf /etc/pacman.d/gnupg && \
+#     pacman-key --init
 
 # add the keys from the offical keyring as trusted keys
 RUN pacman-key --populate archlinux

--- a/ArchLinux/Dockerfile
+++ b/ArchLinux/Dockerfile
@@ -42,10 +42,10 @@ RUN groupadd -r makepkg && \
 
 USER makepkg
 WORKDIR /tmp/makepkg
-             
+
 RUN curl -s -SL https://aur.archlinux.org/cgit/aur.git/snapshot/ipe.tar.gz | tar xzv && \
     cd ipe && makepkg --noconfirm
-    
+
 RUN curl -s -SL https://aur.archlinux.org/cgit/aur.git/snapshot/esbtl.tar.gz | tar xzv && \
     cd esbtl && makepkg --noconfirm
 
@@ -60,4 +60,6 @@ RUN pacman -U --noconfirm ipe/*.pkg.tar.xz esbtl/*.pkg.tar.xz leda-free/*.pkg.ta
     rm -rf ipe esbtl leda-free librs
 
 ENV CGAL_TEST_PLATFORM="ArchLinux"
-ENV CGAL_CMAKE_FLAGS="(\"-DWITH_CGAL_Qt3:BOOL=OFF\")"
+ENV CGAL_CMAKE_FLAGS="(\"-DWITH_CGAL_Qt3:BOOL=OFF\" \"-DLEDA_INCLUDE_DIR=/usr/include/LEDA\")"
+# ENV CGAL_CMAKE_FLAGS="(\"-DWITH_CGAL_Qt3:BOOL=OFF\" \"-DWITH_LEDA:BOOL=ON\" \"-DLEDA_INCLUDE_DIR=/usr/include/LEDA\")"
+# ENV CGAL_CMAKE_FLAGS="(\"-DWITH_CGAL_Qt3:BOOL=OFF\" \"-DWITH_GMP:BOOL=ON\" \"-DWITH_MPFR:BOOL=ON\" \"-DWITH_MPFI:BOOL=ON\" \"-DWITH_NTL:BOOL=ON\" \"-DWITH_RS:BOOL=ON\" \"-DWITH_RS3:BOOL=ON\" \"-DWITH_LEDA:BOOL=ON\" \"-DLEDA_INCLUDE_DIR=/usr/include/LEDA\")"

--- a/ArchLinux/Dockerfile
+++ b/ArchLinux/Dockerfile
@@ -69,26 +69,12 @@ RUN for PKG in ipe libqglviewer esbtl leda-free librs; do \
         pushd ${PKG} && makepkg --noconfirm && popd; \
     done
 
-# RUN curl -sSL https://aur.archlinux.org/cgit/aur.git/snapshot/ipe.tar.gz | tar xzv && \
-#     cd ipe && makepkg --noconfirm
-# RUN curl -sSL https://aur.archlinux.org/cgit/aur.git/snapshot/libqglviewer.tar.gz | tar xzv && \
-#     cd libqglviewer && makepkg --noconfirm
-# RUN curl -sSL https://aur.archlinux.org/cgit/aur.git/snapshot/esbtl.tar.gz | tar xzv && \
-#     cd esbtl && makepkg --noconfirm
-# RUN curl -sSL https://aur.archlinux.org/cgit/aur.git/snapshot/leda-free.tar.gz | tar xzv && \
-#     cd leda-free && makepkg --noconfirm
-# RUN curl -sSL https://aur.archlinux.org/cgit/aur.git/snapshot/librs.tar.gz | tar xzv && \
-#     cd librs && makepkg --noconfirm
-
 # install AUR packages and get rid of the build directories afterwards
 USER root
 RUN for PKG in ipe libqglviewer esbtl leda-free librs; do \
         pacman -U --noconfirm ${PKG}/*.pkg.tar.xz && \
         rm -rf ${PKG}; \
     done
-
-# RUN pacman -U --noconfirm ipe/*.pkg.tar.xz libqglviewer/*.pkg.tar.xz esbtl/*.pkg.tar.xz leda-free/*.pkg.tar.xz librs/*.pkg.tar.xz && \
-#     rm -rf ipe libqglviewer esbtl leda-free librs
 
 ENV CGAL_TEST_PLATFORM="ArchLinux"
 

--- a/ArchLinux/Dockerfile
+++ b/ArchLinux/Dockerfile
@@ -60,6 +60,8 @@ RUN pacman -U --noconfirm ipe/*.pkg.tar.xz esbtl/*.pkg.tar.xz leda-free/*.pkg.ta
     rm -rf ipe esbtl leda-free librs
 
 ENV CGAL_TEST_PLATFORM="ArchLinux"
+
+# LEDA includes are in a nonstandard location (/usr/include/LEDA/LEDA/...
+# instead of just /usr/include/LEDA/...) in Stephan Friedrich's AUR package,
+# to avoid conflicts with other files.
 ENV CGAL_CMAKE_FLAGS="(\"-DWITH_CGAL_Qt3:BOOL=OFF\" \"-DLEDA_INCLUDE_DIR=/usr/include/LEDA\")"
-# ENV CGAL_CMAKE_FLAGS="(\"-DWITH_CGAL_Qt3:BOOL=OFF\" \"-DWITH_LEDA:BOOL=ON\" \"-DLEDA_INCLUDE_DIR=/usr/include/LEDA\")"
-# ENV CGAL_CMAKE_FLAGS="(\"-DWITH_CGAL_Qt3:BOOL=OFF\" \"-DWITH_GMP:BOOL=ON\" \"-DWITH_MPFR:BOOL=ON\" \"-DWITH_MPFI:BOOL=ON\" \"-DWITH_NTL:BOOL=ON\" \"-DWITH_RS:BOOL=ON\" \"-DWITH_RS3:BOOL=ON\" \"-DWITH_LEDA:BOOL=ON\" \"-DLEDA_INCLUDE_DIR=/usr/include/LEDA\")"

--- a/ArchLinux/Dockerfile
+++ b/ArchLinux/Dockerfile
@@ -20,7 +20,7 @@ RUN pacman-key --populate archlinux
 RUN pacman-key --refresh-keys
 
 # Now, we are good to update the base system.
-RUN pacman -Su --noconfirm && \
+RUN pacman -Syyu --noconfirm && \
     pacman-db-upgrade
 
 # Update the database of trusted SSL certificates;

--- a/ArchLinux/Dockerfile
+++ b/ArchLinux/Dockerfile
@@ -42,7 +42,7 @@ RUN pacman -S --noconfirm reflector && \
               --save /etc/pacman.d/mirrorlist
 
 # Finally, install additional packages beyond the baseline.
-RUN pacman -S --noconfirm \
+RUN pacman -S --needed --noconfirm \
               base-devel boost cmake \
               eigen \
               glew glu mesa \
@@ -52,7 +52,7 @@ RUN pacman -S --noconfirm \
 # Install dependencies of the AUR (user repository) packages to be built from source later:
 # ipe: freetype2, lua52, poppler, python2, zlib
 # leda-free: tcsh
-RUN pacman -S --noconfirm --asdeps \
+RUN pacman -S --needed --noconfirm --asdeps \
     freetype2 lua52 poppler python2 zlib \
     tcsh
 

--- a/ArchLinux/Dockerfile
+++ b/ArchLinux/Dockerfile
@@ -22,6 +22,7 @@ RUN pacman -S --noconfirm \
               mesa \
               mpfi \
               mpfr \
+              ntl \
               poppler \
               python2 \
               libqglviewer \

--- a/ArchLinux/Dockerfile
+++ b/ArchLinux/Dockerfile
@@ -33,6 +33,14 @@ RUN trust extract-compat
 RUN test -e /etc/pacman.d/mirrorlist.pacnew && \
     sed -e 's|^#\(.*Server.*\.fr/.*\)$|\1|' /etc/pacman.d/mirrorlist.pacnew > /etc/pacman.d/mirrorlist
 
+# Install and run reflector to get determine reasonably fast and up-to-date mirrors
+RUN pacman -S --noconfirm reflector && \
+    reflector --verbose \
+              --country France --country Germany \
+              --protocol http --protocol https --protocol ftp \
+              --latest 32 --sort rate --number 16 \
+              --save /etc/pacman.d/mirrorlist
+
 # Finally, install additional packages beyond the baseline.
 RUN pacman -S --noconfirm \
               base-devel boost cmake \

--- a/ArchLinux/Dockerfile
+++ b/ArchLinux/Dockerfile
@@ -8,8 +8,8 @@ MAINTAINER Philipp Moeller <bootsarehax@gmail.com>, Alexander Kobel <alexander.k
 RUN pacman -Sy --noconfirm archlinux-keyring
 
 # remove the old database of trusted keys the hard way and initialize a new database
-# (Commented because it is currently unnecessary and takes a while;
-# should only be used as a last resort if the base image is /really, really/ old.)
+# This Should hopefully become unnecessary at some point, and should be commented because it takes a while;
+# but right now it's required as a last resort bacause the base image is really, /really/ ancient.)
 RUN rm -rf /etc/pacman.d/gnupg && \
     pacman-key --init
 

--- a/ArchLinux/Dockerfile
+++ b/ArchLinux/Dockerfile
@@ -1,41 +1,58 @@
 FROM base/archlinux:latest
-MAINTAINER Philipp Moeller <bootsarehax@gmail.com>
+MAINTAINER Philipp Moeller <bootsarehax@gmail.com>, Alexander Kobel <alexander.kobel@mpi-inf.mpg.de>
 
 # base/archlinux is really old; in particular, the packager keys are horribly outdated.
-# We delete the original keyring and refresh it from scratch before updating and installing new packages.
-RUN pacman -Sy --noconfirm && \
-    rm -rf /etc/pacman.d/gnupg && \
-    pacman-key --init && \
-    pacman-key --populate archlinux && \
-    pacman-key --refresh-keys && \
-    pacman -Su --noconfirm && \
+# We delete the original keyring and refresh it from scratch before the real setup:
+
+# install the official Arch Linux keyring package
+RUN pacman -Sy --noconfirm archlinux-keyring
+
+# remove the old database of trusted keys the hard way and initialize a new database
+# (Commented because it is currently unnecessary and takes a while;
+# should only be used as a last resort if the base image is /really, really/ old.)
+RUN rm -rf /etc/pacman.d/gnupg && \
+    pacman-key --init
+
+# add the keys from the offical keyring as trusted keys
+RUN pacman-key --populate archlinux
+
+# get updates to the trusted keys from the keyservers
+RUN pacman-key --refresh-keys
+
+# Now, we are good to update the base system.
+RUN pacman -Su --noconfirm && \
     pacman-db-upgrade
 
-# freetype2, lua52, poppler, python2, zlib are depdendencies of ipe
-RUN pacman -S --noconfirm \
-              base-devel \
-              boost \
-              cmake \
-              eigen \
-              freetype2 \
-              glew \
-              glu \
-              gmp \
-              lua52 \
-              mesa \
-              mpfi \
-              mpfr \
-              ntl \
-              poppler \
-              python2 \
-              libqglviewer \
-              qt5-base \
-              qt5-script \
-              qt5-svg \
-              qt5-tools \
-              zlib && \
-    yes|pacman -Scc # clean up
+# Update the database of trusted SSL certificates;
+# otherwise, curl will fail later to download the AUR packages
+RUN trust extract-compat
 
+# We probably also need to update the list of mirrors;
+# it's not automatically overwritten by the previous update through pacman.
+# By default, all the servers are commented out; we uncomment the ones with French TLD.
+RUN test -e /etc/pacman.d/mirrorlist.pacnew && \
+    sed -e 's|^#\(.*Server.*\.fr/.*\)$|\1|' /etc/pacman.d/mirrorlist.pacnew > /etc/pacman.d/mirrorlist
+
+# Finally, install additional packages beyond the baseline.
+RUN pacman -S --noconfirm \
+              base-devel boost cmake \
+              eigen \
+              glew glu mesa \
+              gmp mpfr mpfi ntl \
+              qt5-base qt5-script qt5-svg qt5-tools
+
+# Install dependencies of the AUR (user repository) packages to be built from source later:
+# ipe: freetype2, lua52, poppler, python2, zlib
+# leda-free: tcsh
+RUN pacman -S --noconfirm --asdeps \
+    freetype2 lua52 poppler python2 zlib \
+    tcsh
+
+# clean up the package cache
+RUN yes | pacman -Scc
+
+# create a group for building AUR (user contributed) packages from sources
+# (not allowed as root for security reasons)
 RUN groupadd -r makepkg && \
     useradd -r -g makepkg makepkg && \
     mkdir /tmp/makepkg && \
@@ -46,21 +63,32 @@ RUN groupadd -r makepkg && \
 USER makepkg
 WORKDIR /tmp/makepkg
 
-RUN curl -s -SL https://aur.archlinux.org/cgit/aur.git/snapshot/ipe.tar.gz | tar xzv && \
-    cd ipe && makepkg --noconfirm
+# get and build AUR packages
+RUN for PKG in ipe libqglviewer esbtl leda-free librs; do \
+        curl -sSL https://aur.archlinux.org/cgit/aur.git/snapshot/${PKG}.tar.gz | tar xzv && \
+        pushd ${PKG} && makepkg --noconfirm && popd; \
+    done
 
-RUN curl -s -SL https://aur.archlinux.org/cgit/aur.git/snapshot/esbtl.tar.gz | tar xzv && \
-    cd esbtl && makepkg --noconfirm
+# RUN curl -sSL https://aur.archlinux.org/cgit/aur.git/snapshot/ipe.tar.gz | tar xzv && \
+#     cd ipe && makepkg --noconfirm
+# RUN curl -sSL https://aur.archlinux.org/cgit/aur.git/snapshot/libqglviewer.tar.gz | tar xzv && \
+#     cd libqglviewer && makepkg --noconfirm
+# RUN curl -sSL https://aur.archlinux.org/cgit/aur.git/snapshot/esbtl.tar.gz | tar xzv && \
+#     cd esbtl && makepkg --noconfirm
+# RUN curl -sSL https://aur.archlinux.org/cgit/aur.git/snapshot/leda-free.tar.gz | tar xzv && \
+#     cd leda-free && makepkg --noconfirm
+# RUN curl -sSL https://aur.archlinux.org/cgit/aur.git/snapshot/librs.tar.gz | tar xzv && \
+#     cd librs && makepkg --noconfirm
 
-RUN curl -s -SL https://aur.archlinux.org/cgit/aur.git/snapshot/leda-free.tar.gz | tar xzv && \
-    cd leda-free && makepkg --noconfirm
-
-RUN curl -s -SL https://aur.archlinux.org/cgit/aur.git/snapshot/librs.tar.gz | tar xzv && \
-    cd librs && makepkg --noconfirm
-
+# install AUR packages and get rid of the build directories afterwards
 USER root
-RUN pacman -U --noconfirm ipe/*.pkg.tar.xz esbtl/*.pkg.tar.xz leda-free/*.pkg.tar.xz librs/*.pkg.tar.xz && \
-    rm -rf ipe esbtl leda-free librs
+RUN for PKG in ipe libqglviewer esbtl leda-free librs; do \
+        pacman -U --noconfirm ${PKG}/*.pkg.tar.xz && \
+        rm -rf ${PKG}; \
+    done
+
+# RUN pacman -U --noconfirm ipe/*.pkg.tar.xz libqglviewer/*.pkg.tar.xz esbtl/*.pkg.tar.xz leda-free/*.pkg.tar.xz librs/*.pkg.tar.xz && \
+#     rm -rf ipe libqglviewer esbtl leda-free librs
 
 ENV CGAL_TEST_PLATFORM="ArchLinux"
 

--- a/ArchLinux/Dockerfile
+++ b/ArchLinux/Dockerfile
@@ -1,9 +1,12 @@
 FROM base/archlinux:latest
 MAINTAINER Philipp Moeller <bootsarehax@gmail.com>
 
-# base/archlinux is really old and we need to perform some manual
-# magic when updating
+# base/archlinux is really old; in particular, the packager keys are horribly outdated.
+# We delete the original keyring and refresh it from scratch before updating and installing new packages.
 RUN pacman -Sy --noconfirm && \
+    rm -rf /etc/pacman.d/gnupg && \
+    pacman-key --init && \
+    pacman-key --populate archlinux && \
     pacman-key --refresh-keys && \
     pacman -Su --noconfirm && \
     pacman-db-upgrade


### PR DESCRIPTION
NTL is from the official package repository, LEDA-free and RS from the public user repository (maintained by a colleague of mine and myself).
I just recognized that Philipp refrained from adding RS due to doubts about the licensing (#26). I think this is not a problem: according to personal communication with Fabrice Rouillier, the [RS license](http://vegas.loria.fr/rs/rslicense.txt) is meant to be "morally" LGPL2 (though I'm aware that it doesn't read that way). If you want formal consent by him, I suppose it's best to contact him immediately without me as a man-in-the-middle; I'm sure he'll grant it.
I'm less confident about the implications of Docker images with GPL'ed software, by the way, but I guess someone else thought about that already...