### PR TITLE
Add an image to test the latest clang on Ubuntu.

### DIFF
--- a/Ubuntu-clang-latest/Dockerfile
+++ b/Ubuntu-clang-latest/Dockerfile
@@ -1,0 +1,30 @@
+FROM cgal/testsuite-docker:ubuntu
+
+MAINTAINER Maxime Gimeno
+
+#install the necessary packages
+RUN apt-get update \
+ && apt-get install -y python \
+ && apt-get install -y subversion 
+
+#download llvm and clang from trunk
+RUN cd /tmp \
+ && svn co http://llvm.org/svn/llvm-project/llvm/trunk llvm \
+ && cd ./llvm/tools \
+ && svn co http://llvm.org/svn/llvm-project/cfe/trunk clang 
+
+#build llvm and clang
+RUN cd  /tmp/ \
+ && mkdir build \
+ && cd ./build \
+ && cmake -DCMAKE_CXX_COMPILER:FILEPATH=/usr/bin/g++ ../llvm \
+ && make -j"$(nproc)"
+
+#Clean-up and set some ENV variables
+RUN cd /tmp \
+ && rm -rf ./llvm
+ENV PATH="/tmp/build/bin:${PATH}"
+ENV CGAL_TEST_PLATFORM="Ubuntu-clang-latest"
+ENV CC=/tmp/build/bin/clang
+ENV CXX=/tmp/build/bin/clang++
+ENV CGAL_CMAKE_FLAGS="(\"-DCGAL_CXX_FLAGS=-DDONT_USE_BOOST_PROGRAM_OPTIONS\" \"-DWITH_CGAL_Qt3:BOOL=OFF\" \"-DCMAKE_C_COMPILER:FILEPATH=/tmp/build/bin/clang\" \"-DCMAKE_CXX_COMPILER:FILEPATH=/tmp/build/bin/clang++ \")"

--- a/Ubuntu-clang-latest/Dockerfile
+++ b/Ubuntu-clang-latest/Dockerfile
@@ -27,4 +27,4 @@ ENV PATH="/tmp/build/bin:${PATH}"
 ENV CGAL_TEST_PLATFORM="Ubuntu-clang-latest"
 ENV CC=/tmp/build/bin/clang
 ENV CXX=/tmp/build/bin/clang++
-ENV CGAL_CMAKE_FLAGS="(\"-DCGAL_CXX_FLAGS=-DDONT_USE_BOOST_PROGRAM_OPTIONS\" \"-DWITH_CGAL_Qt3:BOOL=OFF\" \"-DCMAKE_C_COMPILER:FILEPATH=/tmp/build/bin/clang\" \"-DCMAKE_CXX_COMPILER:FILEPATH=/tmp/build/bin/clang++ \")"
+ENV CGAL_CMAKE_FLAGS="(\"-DCGAL_CXX_FLAGS=-DDONT_USE_BOOST_PROGRAM_OPTIONS -Wthread-safety\" \"-DWITH_CGAL_Qt3:BOOL=OFF\" \"-DCMAKE_C_COMPILER:FILEPATH=/tmp/build/bin/clang\" \"-DCMAKE_CXX_COMPILER:FILEPATH=/tmp/build/bin/clang++ \")"

--- a/Ubuntu-clang-latest/Dockerfile
+++ b/Ubuntu-clang-latest/Dockerfile
@@ -5,26 +5,17 @@ MAINTAINER Maxime Gimeno
 #install the necessary packages
 RUN apt-get update \
  && apt-get install -y python \
- && apt-get install -y subversion 
-
-#download llvm and clang from trunk
-RUN cd /tmp \
+ && apt-get install -y subversion \
+ && apt-get clean -y \
+ && cd /tmp \
  && svn co http://llvm.org/svn/llvm-project/llvm/trunk llvm \
  && cd ./llvm/tools \
- && svn co http://llvm.org/svn/llvm-project/cfe/trunk clang 
-
-#build llvm and clang
-RUN cd  /tmp/ \
- && mkdir build \
+ && svn co http://llvm.org/svn/llvm-project/cfe/trunk clang \
+ && cd /tmp && mkdir build \
  && cd ./build \
  && cmake -DCMAKE_CXX_COMPILER:FILEPATH=/usr/bin/g++ ../llvm \
- && make -j"$(nproc)"
-
-#Clean-up and set some ENV variables
-RUN cd /tmp \
- && rm -rf ./llvm
-ENV PATH="/tmp/build/bin:${PATH}"
+ && make -j"$(nproc)" \
+ && make -j"$(nproc)" install \
+ && cd /tmp && rm -rf build llvm 
 ENV CGAL_TEST_PLATFORM="Ubuntu-clang-latest"
-ENV CC=/tmp/build/bin/clang
-ENV CXX=/tmp/build/bin/clang++
-ENV CGAL_CMAKE_FLAGS="(\"-DCGAL_CXX_FLAGS=-DDONT_USE_BOOST_PROGRAM_OPTIONS -Wthread-safety\" \"-DWITH_CGAL_Qt3:BOOL=OFF\" \"-DCMAKE_C_COMPILER:FILEPATH=/tmp/build/bin/clang\" \"-DCMAKE_CXX_COMPILER:FILEPATH=/tmp/build/bin/clang++ \")"
+ENV CGAL_CMAKE_FLAGS="(\"-DCGAL_CXX_FLAGS=-DDONT_USE_BOOST_PROGRAM_OPTIONS -Wthread-safety\" \"-#DWITH_CGAL_Qt3:BOOL=OFF\")"


### PR DESCRIPTION
This PR proposes an ubuntu based image that installs the latest clang from trunk and use it as c and c++ compiler.