### PR TITLE
Install newest cmake

### DIFF
--- a/CentOS-6/Dockerfile
+++ b/CentOS-6/Dockerfile
@@ -3,7 +3,6 @@ MAINTAINER Laurent Rineau <laurent.rineau@cgal.org>
 
 RUN yum -y install epel-release.noarch; yum -y update; yum clean all
 RUN yum -y install \
-    cmake \
     curl \
     eigen3-devel.noarch \
     gcc-c++ \
@@ -20,6 +19,13 @@ RUN yum -y install \
     qt5-qttools-devel.x86_64 \
     tar \
     zlib-devel.x86_64 && yum clean all
+
+RUN curl -fSL "https://cmake.org/files/v3.1/cmake-3.1.3-Linux-x86_64.sh" -o /usr/cmake.sh
+RUN cd /usr \
+ && chmod +x ./cmake.sh
+
+RUN cd /usr \
+&& ./cmake.sh --skip-license
 
 ENV BOOST_MAJOR=1 BOOST_MINOR=48 BOOST_PATCH=0
 RUN curl -s -SL http://sourceforge.net/projects/boost/files/boost/${BOOST_MAJOR}.${BOOST_MINOR}.${BOOST_PATCH}/boost_${BOOST_MAJOR}_${BOOST_MINOR}_${BOOST_PATCH}.tar.gz | tar xz && \

--- a/CentOS-7/Dockerfile
+++ b/CentOS-7/Dockerfile
@@ -5,7 +5,6 @@ RUN yum -y update; yum clean all
 RUN yum -y install epel-release.noarch; yum clean all
 RUN yum -y update; yum -y install \
     boost-devel.x86_64 \
-    cmake \
     curl \
     eigen3-devel.noarch \
     gcc-c++ \
@@ -21,6 +20,13 @@ RUN yum -y update; yum -y install \
     qt5-qttools-devel.x86_64 \
     tar \
     zlib-devel.x86_64; yum clean all
+
+RUN curl -fSL "https://cmake.org/files/v3.6/cmake-3.6.2-Linux-x86_64.sh" -o /usr/cmake.sh
+RUN cd /usr \
+ && chmod +x ./cmake.sh
+
+RUN cd /usr \
+&& ./cmake.sh --skip-license
 
 RUN cd /etc/yum.repos.d/ && \
     curl -s -SLO https://copr.fedoraproject.org/coprs/rineau/libQGLViewer-qt5/repo/epel-7/rineau-libQGLViewer-qt5-epel-7.repo && \

--- a/Debian-stable/Dockerfile
+++ b/Debian-stable/Dockerfile
@@ -3,7 +3,6 @@ MAINTAINER Philipp Moeller <bootsarehax@gmail.com>
 
 RUN apt-get clean && apt-get update && apt-get install -y \
     build-essential \
-    cmake \
     geomview \
     libboost-dev \
     libboost-program-options-dev \
@@ -22,7 +21,15 @@ RUN apt-get clean && apt-get update && apt-get install -y \
     qttools5-dev \
     qttools5-dev-tools \
     tar \
-    zlib1g-dev
+    zlib1g-dev \
+    curl
+
+RUN curl -fSL "https://cmake.org/files/v3.1/cmake-3.1.3-Linux-x86_64.sh" -o /usr/cmake.sh
+RUN cd /usr \
+ && chmod +x ./cmake.sh
+
+RUN cd /usr \
+&& ./cmake.sh --skip-license
 
 ENV CGAL_TEST_PLATFORM="Debian-Stable"
 ENV CGAL_CMAKE_FLAGS="(\"-DWITH_CGAL_Qt3:BOOL=OFF\")"


### PR DESCRIPTION
This PR fixes #46 .
It installs cmake 3.1.3 for Debian-stable and CentOs-6, and cmake 3.6.2 for CentOs-7.