### PR TITLE
Add a new image with fsanitize=address

### DIFF
--- a/Fedora-rawhide-fsanitize/Dockerfile
+++ b/Fedora-rawhide-fsanitize/Dockerfile
@@ -1,0 +1,7 @@
+FROM cgal/testsuite-docker:fedora-rawhide
+MAINTAINER Maxime Gimeno <maxime.gimeno@gmail.com>
+RUN dnf -y install \
+    libasan.x86_64 \
+    tar && dnf clean all
+ENV CGAL_TEST_PLATFORM="Fedora-rawhide-fsanitize"
+ENV CGAL_CMAKE_FLAGS="( \"-DCMAKE_BUILD_TYPE=Debug\" \"-DCMAKE_CXX_FLAGS=-Og -g -fsanitize=address\")"


### PR DESCRIPTION
This PR fixes #57 .
It adds an image for Fedora-rawhide with the flags -fsanitize=address, -Og and -g.