### PR TITLE
Fix centOs 6 32bits

### DIFF
--- a/CentOS-6-32/Dockerfile
+++ b/CentOS-6-32/Dockerfile
@@ -21,12 +21,7 @@ RUN yum -y update; yum -y install \
                    tar \
                    zlib-devel.i686
 RUN yum clean all
-RUN curl -fSL "https://cmake.org/files/v3.1/cmake-3.1.3-Linux-i386.sh" -o /usr/cmake.sh
-RUN cd /usr \
- && chmod +x ./cmake.sh
-
-RUN cd /usr \
-&& ./cmake.sh --skip-license
+RUN curl -fSL "https://cmake.org/files/v3.1/cmake-3.1.3-Linux-i386.sh" -o cmake.sh && bash cmake.sh --skip-license && rm cmake.sh
 
 ENV BOOST_MAJOR=1 BOOST_MINOR=48 BOOST_PATCH=0
 RUN curl -s -SL http://sourceforge.net/projects/boost/files/boost/${BOOST_MAJOR}.${BOOST_MINOR}.${BOOST_PATCH}/boost_${BOOST_MAJOR}_${BOOST_MINOR}_${BOOST_PATCH}.tar.gz | tar xz

--- a/CentOS-6-32/Dockerfile
+++ b/CentOS-6-32/Dockerfile
@@ -4,7 +4,6 @@ MAINTAINER Philipp Moeller <bootsarehax@gmail.com>
 RUN yum -y update; yum clean all
 RUN yum -y install epel-release.noarch
 RUN yum -y update; yum -y install \
-                   cmake \
                    eigen3-devel.noarch \
                    gcc-c++ \
                    glew-devel.i686 \
@@ -22,6 +21,12 @@ RUN yum -y update; yum -y install \
                    tar \
                    zlib-devel.i686
 RUN yum clean all
+RUN curl -fSL "https://cmake.org/files/v3.1/cmake-3.1.3-Linux-x86_64.sh" -o /usr/cmake.sh
+RUN cd /usr \
+ && chmod +x ./cmake.sh
+
+RUN cd /usr \
+&& ./cmake.sh --skip-license
 
 ENV BOOST_MAJOR=1 BOOST_MINOR=48 BOOST_PATCH=0
 RUN curl -s -SL http://sourceforge.net/projects/boost/files/boost/${BOOST_MAJOR}.${BOOST_MINOR}.${BOOST_PATCH}/boost_${BOOST_MAJOR}_${BOOST_MINOR}_${BOOST_PATCH}.tar.gz | tar xz

--- a/CentOS-6-32/Dockerfile
+++ b/CentOS-6-32/Dockerfile
@@ -21,7 +21,7 @@ RUN yum -y update; yum -y install \
                    tar \
                    zlib-devel.i686
 RUN yum clean all
-RUN curl -fSL "https://cmake.org/files/v3.1/cmake-3.1.3-Linux-x86_64.sh" -o /usr/cmake.sh
+RUN curl -fSL "https://cmake.org/files/v3.1/cmake-3.1.3-Linux-i386.sh" -o /usr/cmake.sh
 RUN cd /usr \
  && chmod +x ./cmake.sh
 


### PR DESCRIPTION
This fixes the image CentOS-6 32bits, that still has a deprecated CMake.