### PR TITLE
Install parallel studio 2017 on CentOS-7-ICC.

### DIFF
--- a/CentOS-7-ICC/Dockerfile
+++ b/CentOS-7-ICC/Dockerfile
@@ -3,21 +3,23 @@ MAINTAINER Philipp Moeller <bootsarehax@gmail.com>
 
 RUN yum -y update; yum clean all
 RUN yum -y install \
+    wget \
     gcc-c++ \
     glibc-devel.x86_64 \
     libstdc++-devel.x86_64 \
     tar
 
-RUN curl -s -SL http://registrationcenter-download.intel.com/akdlm/irc_nas/7538/parallel_studio_xe_2015_update3.tgz | tar xzv && \
-    cd /parallel_studio_xe_2015_update3/rpm && \
-    rpm -ivh --nodeps --ignorearch --excludedocs \
-    intel-compilerpro-*.rpm \
-    intel-compilerproc-*.rpm \
-    intel-mkl-*.rpm \
-    intel-openmp*.rpm && \ 
-    cd / && rm -rf parallel_studio_xe_2015_update3
+COPY config.cfg /tmp/icc-config.cfg
 
-RUN echo "source /opt/intel/composer_xe_2015.3.187/pkg_bin/compilervars.sh intel64 \&\& source /opt/intel/composer_xe_2015.3.187/mkl/bin/mklvars.sh intel64" > /etc/profile.d/intel.sh
+RUN cd /tmp && \
+  wget -O icc.tgz http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11542/parallel_studio_xe_2017_update4_composer_edition_for_cpp_online.tgz && \
+  tar -xvzf icc.tgz && \
+  cd /tmp/parallel_studio_xe_2017_update4_composer_edition_for_cpp_online && \
+  bash ./install.sh --silent=/tmp/icc-config.cfg && \
+  cd .. && \
+  rm -rf parallel_studio_xe_2017_update4_composer_edition_for_cpp_online icc.tgz
+
+RUN echo "source /opt/intel/parallel_studio_xe_2017.4.056/compilers_and_libraries_2017/linux/pkg_bin/compilervars.sh intel64 \&\& source /opt/intel/parallel_studio_xe_2017.4.056/compilers_and_libraries_2017/linux/mkl/bin/mklvars.sh intel64" > /etc/profile.d/intel.sh
 ENV CC=icc CXX=icpc BASH_ENV=/etc/profile.d/intel.sh
 ENV CGAL_TEST_PLATFORM="CentOS7-ICC"
 ENV CGAL_CMAKE_FLAGS="('-DCMAKE_CXX_FLAGS=-w1')"

--- a/CentOS-7-ICC/config.cfg
+++ b/CentOS-7-ICC/config.cfg
@@ -1,0 +1,10 @@
+ACCEPT_EULA=accept
+CONTINUE_WITH_OPTIONAL_ERROR=yes
+PSET_INSTALL_DIR=/opt/intel
+CONTINUE_WITH_INSTALLDIR_OVERWRITE=yes
+PSET_MODE=install
+ACTIVATION_TYPE=license_file
+CLUSTER_INSTALL_TEMP=/tmp/install.mCJ1G9
+PHONEHOME_SEND_USAGE_DATA=no
+ARCH_SELECTED=INTEL64
+COMPONENTS=;intel-comp-l-all-vars__noarch;intel-comp-l-all-common__noarch;intel-comp-l-all__x86_64;intel-comp-l-ps-ss-bec__x86_64;intel-comp-l-ps__x86_64;intel-comp-l-ps-ss__x86_64;intel-openmp-l-all__x86_64;intel-openmp-l-ps-ss-bec__x86_64;intel-openmp-l-ps-ss__x86_64;intel-openmp-l-ps-bec__x86_64;intel-openmp-l-ps-libs__x86_64;intel-openmp-l-ps__x86_64;intel-openmp-l-ps-libs-jp__x86_64;intel-openmp-l-ps-jp__x86_64;intel-tbb-libs__noarch;intel-comp-all-doc__noarch;intel-comp-ps-doc-jp__noarch;intel-icc-doc__noarch;intel-icc-ps-doc__noarch;intel-icc-ps-doc-jp__noarch;intel-icc-ps-ss-doc__noarch;intel-icc-l-all-common__noarch;intel-icc-l-all-common-jp__noarch;intel-icc-l-ps-ss-bec-common__noarch;intel-icc-l-ps-common__noarch;intel-icc-l-all__x86_64;intel-icc-l-ps-ss__x86_64;intel-icc-l-ps__x86_64;intel-icc-l-ps-ss-bec__x86_64;intel-mkl-common__noarch;intel-mkl__x86_64;intel-mkl-rt__x86_64;intel-mkl-ps-rt-jp__x86_64;intel-mkl-doc__noarch;intel-mkl-ps-doc__noarch;intel-mkl-ps-doc-jp__noarch;intel-mkl-gnu__x86_64;intel-mkl-gnu-rt__x86_64;intel-mkl-ps-common__noarch;intel-mkl-ps-common-jp__noarch;intel-mkl-ps-common-64bit__x86_64;intel-mkl-common-c__noarch;intel-mkl-common-c-64bit__x86_64;intel-mkl-ps-common-c__noarch;intel-mkl-doc-c__noarch;intel-mkl-ps-doc-c-jp__noarch;intel-mkl-ps-ss-tbb__x86_64;intel-mkl-ps-ss-tbb-rt__x86_64;intel-mkl-gnu-c__x86_64;intel-tbb-devel__noarch;intel-tbb-common__noarch;intel-tbb-ps-common__noarch;intel-tbb-common-jp__noarch;intel-tbb-doc__noarch;intel-tbb-doc-jp__noarch;intel-ism__noarch;intel-ccompxe__noarch;intel-psxe-licensing__noarch;intel-psxe-licensing-doc__noarch;intel-psxe-common__noarch;intel-psxe-doc__noarch;intel-ccompxe-doc__noarch;intel-psxe-common-doc__noarch;intel-icsxe-pset


### PR DESCRIPTION
fixes #69 

A path to the license file may have to be given in the config file with the line 

ACTIVATION_LICENSE_FILE=\<path to file\>