### PR TITLE
Revert "Remove qt5 from the platforms that don't support it on the server"

### DIFF
--- a/Debian-testing/Dockerfile
+++ b/Debian-testing/Dockerfile
@@ -14,17 +14,16 @@ RUN apt-get clean && apt-get update && apt-get install -y \
     libipe-dev \
     libmpfi-dev \
     libmpfr-dev \
-#    libqglviewer-dev-qt5 \
-#    qtbase5-dev \
-#    qtscript5-dev \
-#    qttools5-dev \
-#    qttools5-dev-tools \
-#    libqt5svg5-dev \
-#    libqt5opengl5-dev \
+    libqglviewer-dev-qt5 \
+    qtbase5-dev \
+    qtscript5-dev \
+    qttools5-dev \
+    qttools5-dev-tools \
+    libqt5svg5-dev \
+    libqt5opengl5-dev \
     tar \
     libtbb-dev \
     zlib1g-dev
 
 ENV CGAL_TEST_PLATFORM="Debian-Testing"
 ENV CGAL_CMAKE_FLAGS="(\"-DWITH_CGAL_Qt3:BOOL=OFF\")"
-

--- a/Fedora-32/Dockerfile
+++ b/Fedora-32/Dockerfile
@@ -13,7 +13,7 @@ RUN dnf -y install \
     gmp-devel.i686 \
     ipe.i686 \
     ipe-devel.i686 \
-#    libQGLViewer-devel.i686 \
+    libQGLViewer-devel.i686 \
     libstdc++-devel.i686 \
     libstdc++-devel.x86_64 \
     make \
@@ -21,12 +21,12 @@ RUN dnf -y install \
     mesa-libGLU-devel.i686 \
     mpfr-devel.i686 \
     ntl-devel.i686 \
-#    qt-devel.i686 \
-#    qt3-devel.i686 \
-#    qt5-qtbase-devel.i686 \
-#    qt5-qtscript-devel.i686 \
-#    qt5-qtsvg-devel.i686 \
-#    qt5-qttools-devel.i686 \
+    qt-devel.i686 \
+    qt3-devel.i686 \
+    qt5-qtbase-devel.i686 \
+    qt5-qtscript-devel.i686 \
+    qt5-qtsvg-devel.i686 \
+    qt5-qttools-devel.i686 \
     tar \
     tbb-devel \
     zlib-devel.i686

--- a/Fedora/Dockerfile
+++ b/Fedora/Dockerfile
@@ -12,15 +12,15 @@ RUN dnf -y install \
     ipe-devel.x86_64 \
     OpenMesh-devel \
     opencv-devel \
-#    libQGLViewer-qt5-devel.x86_64 \
+    libQGLViewer-qt5-devel.x86_64 \
     make \
     mpfr-devel.x86_64 \
     mpfi-devel.x86_64 \
     ntl-devel.x86_64 \
-#    qt5-qtbase-devel.x86_64 \
-#    qt5-qtscript-devel.x86_64 \
-#    qt5-qtsvg-devel.x86_64 \
-#    qt5-qttools-devel.x86_64 \
+    qt5-qtbase-devel.x86_64 \
+    qt5-qtscript-devel.x86_64 \
+    qt5-qtsvg-devel.x86_64 \
+    qt5-qttools-devel.x86_64 \
     tar \
     unzip \
     wget \


### PR DESCRIPTION
Reverts CGAL/cgal-testsuite-dockerfiles#86

I will the test of those platforms to renoir (Fedora 28).
