### PR TITLE
Fix "diff missing command" issues on our Fedora images

### DIFF
--- a/Fedora-32/Dockerfile
+++ b/Fedora-32/Dockerfile
@@ -29,6 +29,7 @@ RUN dnf -y install \
     qt5-qttools-devel.i686 \
     tar \
     tbb-devel \
+    diffutils \
     zlib-devel.i686 && dnf clean all
 
 RUN ln -s /usr/lib64/qt5/bin/qhelpgenerator /usr/lib/qt5/bin/qhelpgenerator

--- a/Fedora-rawhide/Dockerfile
+++ b/Fedora-rawhide/Dockerfile
@@ -18,6 +18,7 @@ RUN rpm --import https://src.fedoraproject.org/rpms/fedora-repos/raw/master/f/RP
                    OpenMesh-devel \
                    tbb-devel \
                    zlib-devel.x86_64 \
+		   diffutils \
                    tar && dnf clean all
 
 ENV CGAL_TEST_PLATFORM="Fedora-rawhide"

--- a/Fedora/Dockerfile
+++ b/Fedora/Dockerfile
@@ -26,6 +26,7 @@ RUN dnf -y install \
     wget \
     tbb-devel \
     zlib-devel.x86_64 \
+    diffutils.x86_64 \
     libssh-devel
 
 RUN wget "https://github.com/CGAL/LAStools/archive/master.zip" -O laslib.zip \


### PR DESCRIPTION
add diffutils in the installed pkgs of the Fedora images.