### PR TITLE
Remove ipe

### DIFF
--- a/Debian-testing/Dockerfile
+++ b/Debian-testing/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get clean && apt-get update && apt-get install -y \
     libeigen3-dev \
     libglew1.5-dev \
     libgmp10-dev \
-    libipe-dev \
     libmpfi-dev \
     libmpfr-dev \
     libqglviewer-dev-qt5 \


### PR DESCRIPTION
That will probably probably solve the issue with `statx` and `libpaper1`:

https://travis-ci.com/github/CGAL/cgal-testsuite-dockerfiles/jobs/428787945#L2794
```
Setting up libpaper1:amd64 (1.1.28+b1) ...

debconf: unable to initialize frontend: Dialog

debconf: (TERM is not set, so the dialog frontend is not usable.)

debconf: falling back to frontend: Readline

Creating config file /etc/papersize with new version

stat: cannot statx '/etc/papersize.dpkg-inst': Operation not permitted

dpkg: error processing package libpaper1:amd64 (--configure):

 installed libpaper1:amd64 package post-installation script subprocess returned error exit status 1
```