### PR TITLE
do not test libpointmatcher `master`, but 1.3.1

### DIFF
--- a/Ubuntu/Dockerfile
+++ b/Ubuntu/Dockerfile
@@ -46,6 +46,7 @@ RUN git clone https://github.com/ethz-asl/libnabo.git \
 
 RUN git clone https://github.com/ethz-asl/libpointmatcher.git \
  && cd libpointmatcher \
+ && git switch -d e9a832d \
  && sed -i 's/Boost_USE_STATIC_LIBS  ON/Boost_USE_STATIC_LIBS  OFF/' CMakeLists.txt \
  && SRC_DIR=`pwd` \
  && BUILD_DIR=${SRC_DIR}/build \
@@ -53,6 +54,7 @@ RUN git clone https://github.com/ethz-asl/libpointmatcher.git \
  && cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DPOINTMATCHER_BUILD_EXAMPLES=OFF -DPOINTMATCHER_BUILD_EVALUATIONS=OFF ${SRC_DIR} \
  && make -j"$(nproc)" && make install \
  && cd ../.. && rm -rf libpointmatcher
+ # Commit e9a832d is 1.3.1-178-ge9a832d
 
 RUN git clone --recursive https://github.com/oxfordcontrol/osqp \
  && cd ./osqp \


### PR DESCRIPTION
For the `Ubuntu` images (that are now [Ubuntu 24.04, aka Noble Numbat](https://releases.ubuntu.com/)), the `master` version of `libpointmatcher` does not work. See https://github.com/CGAL/cgal-testsuite-dockerfiles/actions/runs/9239645476/job/25419044232#step:3:10178

This PR switches to commit https://github.com/norlab-ulaval/libpointmatcher/commit/e9a832d, that is described by Git as `1.3.1-178-ge9a832d` (178 commits ahead of the tag `1.3.1`).