### PR TITLE
Add CGAL_SUMMARY_NAME environment variable for custom platform display

### DIFF
--- a/Ubuntu-GCC6-Release/Dockerfile
+++ b/Ubuntu-GCC6-Release/Dockerfile
@@ -3,6 +3,7 @@ ARG dockerfile_url
 ENV DOCKERFILE_URL=$dockerfile_url
 
 ENV CGAL_TEST_PLATFORM="Ubuntu-latest-GCC6-Release"
+ENV CGAL_SUMMARY_NAME="Ubuntu-latest-Release"
 ENV CGAL_CMAKE_FLAGS="(\"-DCGAL_CXX_FLAGS=-DDONT_USE_BOOST_PROGRAM_OPTIONS -Wall -Wextra -O3 -DCGAL_NDEBUG\")"
 ENV INIT_FILE=/tmp/init.cmake
 COPY init.cmake /tmp/init.cmake

--- a/run-testsuite.sh
+++ b/run-testsuite.sh
@@ -116,6 +116,7 @@ touch "$RESULT_FILE"
 
 sed -n '/The CXX compiler/s/-- The CXX compiler identification is/COMPILER_VERSION =/p' < "${CGAL_TESTRESULTS}installation-${CGAL_TEST_PLATFORM}.log" |sed -E "s/ = (.*)/\ = '\1\'/">> "$RESULT_FILE"
 sed -n '/CGAL_VERSION /s/#define //p' < "${CGAL_VERSION_DIR}include/CGAL/version.h" >> "$RESULT_FILE"
+echo "CGAL_SUMMARY_NAME ${CGAL_SUMMARY_NAME:-$CGAL_TEST_PLATFORM}" >> "$RESULT_FILE"
 echo "TESTER ${CGAL_TESTER}" >> "$RESULT_FILE"
 echo "TESTER_NAME ${CGAL_TESTER_NAME}" >> "$RESULT_FILE"
 echo "TESTER_ADDRESS ${CGAL_TESTER_ADDRESS}" >> "$RESULT_FILE"


### PR DESCRIPTION
Add CGAL_SUMMARY_NAME environment variable to allow custom platform names in test results table. This PR is linked with [PR#8622](https://github.com/CGAL/cgal/pull/8622) that handles the display of this new variable in the test results page.
